### PR TITLE
Removed IntMath.cs from csproj and updated Ascii.cs to use built in c# code

### DIFF
--- a/Guava.Net/Base/Ascii.cs
+++ b/Guava.Net/Base/Ascii.cs
@@ -38,6 +38,15 @@ namespace Guava.Base
         public static readonly byte NUL = 0;
 
         #endregion
+        /// <summary>
+        /// Returns a copy of the input string where all of the lower case characters have been converted to upper case.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static String ToUpperCase(String str)
+        {
+            return str.ToUpper();
+        }
 
         /// <summary>
         /// Returns a copy of the input string in which all Upper Case ASCII characters
@@ -47,22 +56,7 @@ namespace Guava.Base
         /// <returns></returns>
         public static String ToLowerCase(String str)
         {
-            for (int i = 0; i < str.Length; i++)
-            {
-                // If we find an upper case character will convert all the characters that follow.
-                if (IsUpperCase(str[i]))
-                {
-                    char[] chars = str.ToCharArray(); // Creates copy to modify 
-                    for (; i < str.Length; i++)
-                    {
-                        char c = chars[i];
-                        if (IsUpperCase(c))
-                            chars[i] = (char)(c ^ 0x20); // XOR 6th bit to convert to all lower case Ex: A = 01000001 => a = 01100001
-                    }
-                    return chars.ToString();
-                }
-            }
-            return str;
+            return str.ToLower(); //.net already has this in the string library
         }
 
         public static char ToLowerCase(char c)

--- a/Guava.Net/Guava.Net.csproj
+++ b/Guava.Net/Guava.Net.csproj
@@ -40,13 +40,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Base\Ascii.cs" />
+    <Compile Include="Base\Defaults.cs" />
     <Compile Include="Base\IPredicate.cs" />
     <Compile Include="Base\Preconditions.cs" />
     <Compile Include="Collection\BitArrayHelper.cs" />
     <Compile Include="Hash\BloomFilter.cs" />
     <Compile Include="Hash\Funnel.cs" />
     <Compile Include="Math\DoubleUtils.cs" />
-    <Compile Include="Math\IntMath.cs" />
     <Compile Include="Math\MathPreconditions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
IntMath.cs is not currently in version control and was keeping project from building

string.toupper and string.tolower do what toupper and tolower were doing already... unless there is a good reason I suggest that you use built in c# libs.